### PR TITLE
Fix: '-u' not longer accepted, use '--username'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ignore test files
 accounts.txt
 success.txt
+*.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple Python script to check if NordVPN accounts listed in a file are valid.
 # Requirements
 
 - The NordVPN CLI tool. [Get it from here](https://nordvpn.com/download/linux/).
-- [Python 3](https://www.python.org/downloads/).
+- [Python 3.7](https://www.python.org/downloads/).
 - An input file containing NordVPN login entries in `email:password` format.
 
 # Installation

--- a/nord-checker.py
+++ b/nord-checker.py
@@ -44,10 +44,11 @@ def check_login(email: str, password: str) -> Union['False', None, str]:
     subprocess.run(['nordvpn', 'logout'], capture_output=True)
 
     login_result = subprocess.run(
-        ['nordvpn', 'login', '-u', email, '-p', password],
+        ['nordvpn', 'login', '--username', email, '--password', password],
         capture_output=True,
         text=True
     )
+
     if not login_result.returncode == 0:
         # Failed to login
         return False

--- a/nord-checker.py
+++ b/nord-checker.py
@@ -115,6 +115,16 @@ def read_file(args) -> None:
                 )
                 print(
                     R+"NordVPN might be temporarily blocking your IP due to too many requests."+E)
+            elif login_result.find("having trouble reaching our servers") == -1:
+                # No response from NordVPN
+                print(
+                    B + f'{count}) Checking ➜',
+                    W + f'{email}:{password}',
+                    '\t\t\t',
+                    R + 'No response' + E
+                )
+                print(
+                    R+"NordVPN might be temporarily blocking your IP due to too many requests."+E)
             else:
                 account_expiration_date = parse_expiration_date(login_result)
                 print(


### PR DESCRIPTION
* _NVPN Version 3.12.2_ seems to no longer accept `-u` as `--username`
* Added a warning for _too many attempts_.